### PR TITLE
Restart unicorn on reboot

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,5 +5,7 @@
   sudo: yes
 - command: systemctl daemon-reload
   sudo: yes
+- command: systemctl enable unicorn
+  becomes: yes
 - command: systemctl start unicorn
   sudo: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,10 +2,13 @@
 # tasks file for ansible_systemd_unicorn
 - name: Unicorn | Copy systemd template to systemd multiuser directory
   template: src=unicorn_systemd dest=/lib/systemd/system/unicorn.service owner=root group=root
-  sudo: yes
-- command: systemctl daemon-reload
-  sudo: yes
-- command: systemctl enable unicorn
   becomes: yes
-- command: systemctl start unicorn
-  sudo: yes
+- name: reload the systemd process after modifying config file
+  command: systemctl daemon-reload
+  becomes: yes
+- name: configure unicorn to restart on reboot
+  command: systemctl enable unicorn
+  becomes: yes
+- name: explicitly start unicorn
+  command: systemctl start unicorn
+  becomes: yes


### PR DESCRIPTION
https://www.digitalocean.com/community/tutorials/how-to-use-systemctl-to-manage-systemd-services-and-units
- Noticed that unicorn wasn't running
  after the server rebooted (after applying security patches)
- This enables unicorn so that it restarts on server reboot
  by creating a symlink from /lib/systemd/system/unicorn.service to /etc/systemd/system/
  (/etc/systemd contains services that systemd starts on boot)
- see Digital Ocean guide above for a quick overview
