### PR TITLE
VSTS-105 - Server Rebuild

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,12 +5,13 @@ galaxy_info:
 
   license: MIT
 
-  min_ansible_version: 2.0
+  min_ansible_version: 2.2
 
   platforms:
     - name: Ubuntu
       versions:
         - xenial
+        - bionic
 
   galaxy_tags:
     - systemd

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,14 +1,16 @@
 ---
 # tasks file for ansible_systemd_unicorn
 - name: Unicorn | Copy systemd template to systemd multiuser directory
-  template: src=unicorn_systemd dest=/lib/systemd/system/unicorn.service owner=root group=root
+  template:
+    src: unicorn_systemd
+    dest: '/lib/systemd/system/unicorn.service'
+    owner: root
+    group: root
   become: yes
-- name: reload the systemd process after modifying config file
-  command: systemctl daemon-reload
-  become: yes
-- name: configure unicorn to restart on reboot
-  command: systemctl enable unicorn
-  become: yes
-- name: explicitly start unicorn
-  command: systemctl start unicorn
+- name: Configure Unicorn to Start on Reboot and Start the Process
+  systemd:
+    name: unicorn
+    daemon_reload: yes
+    enabled: yes
+    state: started
   become: yes

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -2,4 +2,4 @@
 - hosts: localhost
   remote_user: root
   roles:
-    - ansible_systemd_unicorn
+    - ansible-systemd-unicorn


### PR DESCRIPTION
:elephant:

* Use the `systemd` module introduced in ansible >= 2.2 instead
  of commands to configure services.

SEE: https://dev.azure.com/AMA-Ent/AMA-Ent/_workitems/edit/105